### PR TITLE
feat(FilterBar): animated progress overlay only on apply

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/components/ProgressBar/index.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/components/ProgressBar/index.tsx
@@ -16,18 +16,19 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { styled } from '@superset-ui/core';
+import { css, styled } from '@superset-ui/core';
 import { Progress as AntdProgress } from 'antd';
 import { ProgressProps } from 'antd/es/progress/progress';
 
 export interface ProgressBarProps extends ProgressProps {
   striped?: boolean;
+  animated?: boolean;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-const ProgressBar = styled(({ striped, ...props }: ProgressBarProps) => (
+const ProgressBar = styled(({ striped, animated, ...props }: ProgressBarProps) => (
   <AntdProgress data-test="progress-bar" {...props} />
-))`
+))<ProgressBarProps>`
   position: static;
   .ant-progress-inner {
     position: static;
@@ -36,15 +37,35 @@ const ProgressBar = styled(({ striped, ...props }: ProgressBarProps) => (
     position: static;
     ${({ striped }) =>
       striped &&
-      `
-        background-image: linear-gradient(45deg,
-            rgba(255, 255, 255, 0.15) 25%,
-            transparent 25%, transparent 50%,
-            rgba(255, 255, 255, 0.15) 50%,
-            rgba(255, 255, 255, 0.15) 75%,
-            transparent 75%, transparent) !important;
+      css`
+        background-image: linear-gradient(
+          45deg,
+          rgba(255, 255, 255, 0.15) 25%,
+          transparent 25%,
+          transparent 50%,
+          rgba(255, 255, 255, 0.15) 50%,
+          rgba(255, 255, 255, 0.15) 75%,
+          transparent 75%,
+          transparent
+        ) !important;
         background-size: 1rem 1rem !important;
-        `};
+      `};
+    ${({ animated }) =>
+      animated &&
+      css`
+        animation: superset-progress-stripes 1s linear infinite;
+        background-size: 1rem 1rem !important;
+        background-position: 0 0;
+      `};
+  }
+
+  @keyframes superset-progress-stripes {
+    from {
+      background-position: 0 0;
+    }
+    to {
+      background-position: 2rem 0;
+    }
   }
 `;
 

--- a/superset-frontend/packages/superset-ui-core/src/utils/featureFlags.ts
+++ b/superset-frontend/packages/superset-ui-core/src/utils/featureFlags.ts
@@ -22,6 +22,8 @@ import logger from './logging';
 // check into source control. We're hardcoding the supported flags for now.
 export enum FeatureFlag {
   // PLEASE KEEP THE LIST SORTED ALPHABETICALLY
+  AutoApplyDashboardFilters = 'AUTO_APPLY_DASHBOARD_FILTERS',
+  FilterBarProgressIndicator = 'FILTERBAR_PROGRESS_INDICATOR',
   AlertsAttachReports = 'ALERTS_ATTACH_REPORTS',
   AlertReports = 'ALERT_REPORTS',
   AlertReportTabs = 'ALERT_REPORT_TABS',

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterBar.progress-on-apply.test.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/FilterBar.progress-on-apply.test.tsx
@@ -1,0 +1,242 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React from 'react';
+import { act, fireEvent, render, screen } from 'spec/helpers/testing-library';
+import { createStore } from 'spec/helpers/testing-library';
+import FilterBar from '.';
+import { FilterBarOrientation } from 'src/dashboard/types';
+import { FeatureFlag, isFeatureEnabled } from '@superset-ui/core';
+
+jest.useFakeTimers();
+
+// Mock feature flags for these tests
+jest.mock('@superset-ui/core', () => ({
+  ...jest.requireActual('@superset-ui/core'),
+  isFeatureEnabled: jest.fn(),
+}));
+const mockedIsFeatureEnabled = isFeatureEnabled as jest.Mock;
+
+// Mock FilterControls to simulate selection change
+jest.mock('./FilterControls/FilterControls', () => ({
+  __esModule: true,
+  default: ({ onFilterSelectionChange }: any) => {
+    React.useEffect(() => {
+      onFilterSelectionChange(
+        { id: 'test-filter', requiredFirst: false },
+        {
+          filterState: { value: 'abc' },
+          extraFormData: {
+            filters: [{ col: 'test_column', op: 'IN', val: ['abc'] }],
+          },
+        },
+      );
+    }, [onFilterSelectionChange]);
+    return null;
+  },
+}));
+
+const baseState: any = {
+  dashboardInfo: {
+    id: 1,
+    dash_edit_perm: true,
+    filterBarOrientation: 'VERTICAL',
+  },
+  dashboardState: {
+    isRefreshing: false,
+    isFiltersRefreshing: false,
+  },
+  dataMask: {
+    'test-filter': {
+      id: 'test-filter',
+      filterState: { value: undefined },
+      extraFormData: {},
+    },
+  },
+  nativeFilters: {
+    filters: {
+      'test-filter': {
+        id: 'test-filter',
+        name: 'Test Filter',
+        filterType: 'filter_select',
+        targets: [{ datasetId: 1, column: { name: 'test_column' } }],
+        defaultDataMask: {
+          filterState: { value: undefined },
+          extraFormData: {},
+        },
+        controlValues: {
+          enableEmptyFilter: true,
+        },
+        cascadeParentIds: [],
+        scope: {
+          rootPath: ['ROOT_ID'],
+          excluded: [],
+        },
+        type: 'NATIVE_FILTER',
+        description: '',
+        chartsInScope: [],
+        tabsInScope: [],
+      },
+    },
+    filtersState: {},
+  },
+  user: {},
+};
+
+const renderVertical = (state: any) =>
+  render(
+    <FilterBar
+      orientation={FilterBarOrientation.Vertical}
+      verticalConfig={{
+        width: 280,
+        height: 400,
+        offset: 0,
+        filtersOpen: true,
+        toggleFiltersBar: jest.fn(),
+      }}
+    />,
+    { useRedux: true, useRouter: true, initialState: state },
+  );
+
+const renderHorizontal = (state: any) =>
+  render(
+    <FilterBar orientation={FilterBarOrientation.Horizontal} />,
+    { useRedux: true, useRouter: true, initialState: state },
+  );
+
+describe('FilterBar progress overlay shows only on apply', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('Vertical: shows progress on Apply and hides after min duration', async () => {
+    mockedIsFeatureEnabled.mockImplementation(
+      (flag: any) => flag === FeatureFlag.FilterBarProgressIndicator,
+    );
+
+    renderVertical(baseState);
+
+    await act(async () => {
+      jest.advanceTimersByTime(1100);
+    });
+
+    expect(screen.queryByTestId('progress-bar')).not.toBeInTheDocument();
+
+    const applyBtn = screen.getByRole('button', { name: /apply filters/i });
+    expect(applyBtn).not.toHaveAttribute('disabled');
+    act(() => {
+      fireEvent.click(applyBtn);
+    });
+
+    expect(await screen.findByTestId('progress-bar')).toBeInTheDocument();
+    await act(async () => {
+      jest.advanceTimersByTime(200);
+    });
+    expect(screen.getByTestId('progress-bar')).toBeInTheDocument();
+    await act(async () => {
+      jest.advanceTimersByTime(220);
+    });
+    expect(screen.getByTestId('progress-bar')).toBeInTheDocument();
+    await act(async () => {
+      jest.advanceTimersByTime(250);
+    });
+    expect(screen.queryByTestId('progress-bar')).not.toBeInTheDocument();
+  });
+
+  it('Horizontal: shows progress on Apply and hides after min duration', async () => {
+    mockedIsFeatureEnabled.mockImplementation(
+      (flag: any) => flag === FeatureFlag.FilterBarProgressIndicator,
+    );
+
+    renderHorizontal(baseState);
+
+    await act(async () => {
+      jest.advanceTimersByTime(1100);
+    });
+    expect(screen.queryByTestId('progress-bar')).not.toBeInTheDocument();
+
+    const applyBtn = screen.getByRole('button', { name: /apply/i });
+    act(() => fireEvent.click(applyBtn));
+
+    expect(await screen.findByTestId('progress-bar')).toBeInTheDocument();
+    await act(async () => {
+      jest.advanceTimersByTime(200);
+    });
+    expect(screen.getByTestId('progress-bar')).toBeInTheDocument();
+    await act(async () => {
+      jest.advanceTimersByTime(220);
+    });
+    expect(screen.getByTestId('progress-bar')).toBeInTheDocument();
+    await act(async () => {
+      jest.advanceTimersByTime(250);
+    });
+    expect(screen.queryByTestId('progress-bar')).not.toBeInTheDocument();
+  });
+
+  it('Auto-apply: shows progress automatically and hides after min duration', async () => {
+    mockedIsFeatureEnabled.mockImplementation(
+      (flag: any) =>
+        flag === FeatureFlag.FilterBarProgressIndicator ||
+        flag === FeatureFlag.AutoApplyDashboardFilters,
+    );
+
+    const store = createStore(baseState);
+    render(
+      <FilterBar
+        orientation={FilterBarOrientation.Vertical}
+        verticalConfig={{
+          width: 280,
+          height: 400,
+          offset: 0,
+          filtersOpen: true,
+          toggleFiltersBar: jest.fn(),
+        }}
+      />,
+      { useRedux: true, useRouter: true, store },
+    );
+
+    await act(async () => {
+      jest.advanceTimersByTime(1100);
+    });
+    await act(async () => {
+      jest.advanceTimersByTime(700);
+    });
+    expect(await screen.findByTestId('progress-bar')).toBeInTheDocument();
+    await act(async () => {
+      jest.advanceTimersByTime(450);
+    });
+    expect(screen.getByTestId('progress-bar')).toBeInTheDocument();
+    await act(async () => {
+      jest.advanceTimersByTime(250);
+    });
+    expect(screen.queryByTestId('progress-bar')).not.toBeInTheDocument();
+  });
+
+  it('Does not show progress when flag disabled', async () => {
+    mockedIsFeatureEnabled.mockReturnValue(false);
+    renderVertical(baseState);
+    await act(async () => {
+      jest.advanceTimersByTime(1100);
+    });
+    const applyBtn = screen.getByRole('button', { name: /apply filters/i });
+    act(() => fireEvent.click(applyBtn));
+    expect(screen.queryByTestId('progress-bar')).not.toBeInTheDocument();
+  });
+});
+

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Horizontal.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/Horizontal.tsx
@@ -17,9 +17,10 @@
  * under the License.
  */
 
-import { FC, memo, useMemo } from 'react';
-import { DataMaskStateWithId, styled, t } from '@superset-ui/core';
+import { FC, memo, useMemo, useEffect, useRef, useState } from 'react';
+import { DataMaskStateWithId, styled, t, css, useTheme } from '@superset-ui/core';
 import { Loading } from '@superset-ui/core/components';
+import ProgressBar from '@superset-ui/core/components/ProgressBar';
 import { RootState } from 'src/dashboard/types';
 import { useChartLayoutItems } from 'src/dashboard/util/useChartLayoutItems';
 import { useChartIds } from 'src/dashboard/util/charts/useChartIds';
@@ -68,6 +69,7 @@ const HorizontalFilterBar: FC<HorizontalBarProps> = ({
   dataMaskSelected,
   filterValues,
   isInitialized,
+  showProgress,
   onSelectionChange,
   clearAllTriggers,
   onClearAllComplete,
@@ -75,6 +77,43 @@ const HorizontalFilterBar: FC<HorizontalBarProps> = ({
   const dataMask = useSelector<RootState, DataMaskStateWithId>(
     state => state.dataMask,
   );
+  const theme = useTheme();
+  const showProgressRaw = !!showProgress;
+  const hideRef = useRef<number | null>(null);
+  const [progressVisible, setProgressVisible] = useState(false);
+  const [holdRender, setHoldRender] = useState(false);
+  const prevVisible = useRef(false);
+  const visibleSinceRef = useRef<number | null>(null);
+  useEffect(() => {
+    const MIN_VISIBLE_MS = 400;
+    if (hideRef.current) window.clearTimeout(hideRef.current);
+    if (showProgressRaw) {
+      if (!progressVisible) {
+        setProgressVisible(true);
+        visibleSinceRef.current = Date.now();
+      }
+    } else if (progressVisible) {
+      const since = visibleSinceRef.current ?? Date.now();
+      const elapsed = Date.now() - since;
+      const delay = Math.max(0, MIN_VISIBLE_MS - elapsed);
+      hideRef.current = window.setTimeout(() => {
+        setProgressVisible(false);
+        visibleSinceRef.current = null;
+      }, delay);
+    }
+    return () => {
+      if (hideRef.current) window.clearTimeout(hideRef.current);
+    };
+  }, [showProgressRaw, progressVisible]);
+  useEffect(() => {
+    if (!progressVisible && prevVisible.current) {
+      setHoldRender(true);
+      const t = window.setTimeout(() => setHoldRender(false), 220);
+      return () => window.clearTimeout(t);
+    }
+    prevVisible.current = progressVisible;
+    if (progressVisible) setHoldRender(true);
+  }, [progressVisible]);
   const chartIds = useChartIds();
   const chartLayoutItems = useChartLayoutItems();
   const verboseMaps = useChartsVerboseMaps();
@@ -117,6 +156,32 @@ const HorizontalFilterBar: FC<HorizontalBarProps> = ({
           </>
         )}
       </HorizontalBarContent>
+      {(progressVisible || holdRender) && (
+        <div
+          className="filter-progress"
+          css={css`
+            position: absolute;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            z-index: 1;
+            padding: 0 ${16}px 0;
+            margin: 0;
+            opacity: ${progressVisible ? 1 : 0};
+            transition: opacity 0.2s ease-in-out;
+          `}
+        >
+          <ProgressBar
+            percent={99}
+            status="active"
+            showInfo={false}
+            strokeWidth={3}
+            strokeColor={theme.colorPrimary}
+            striped
+            animated
+          />
+        </div>
+      )}
     </HorizontalBar>
   );
 };

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/types.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar/types.ts
@@ -32,6 +32,7 @@ interface CommonFiltersBarProps {
   dataMaskSelected: DataMaskStateWithId;
   filterValues: (Filter | Divider)[];
   isInitialized: boolean;
+  showProgress?: boolean;
   onSelectionChange: (
     filter: Pick<Filter, 'id'> & Partial<Filter>,
     dataMask: Partial<DataMask>,


### PR DESCRIPTION
Summary
Show an animated, striped progress overlay in the Filter Bar only when filters are applied (manual Apply or auto-apply). Removes non-interaction triggers and keeps default behavior when flags are off.

Technical details
- Adds FeatureFlag.FilterBarProgressIndicator and FeatureFlag.AutoApplyDashboardFilters.
- FilterBar manages an applyProgress state; starts on Apply (or auto-apply), hides after the minimal visibility time.
- ActionButtons (vertical) and Horizontal accept showProgress and render a thin overlay progress bar.
- Overlay includes a short fade-out hold to avoid flicker.

Tests
- New unit test covers vertical/horizontal/auto-apply/flag-off behavior with fake timers: FilterBar.progress-on-apply.test.tsx.

Backward compatibility
- 100%: default UI unchanged when flags disabled.

Migrations
- None.

Risk
- Low; UI-only and strictly flag-gated.