### PR TITLE
Email: Remita-branded notification template

### DIFF
--- a/superset/reports/notifications/email.py
+++ b/superset/reports/notifications/email.py
@@ -161,7 +161,11 @@ class EmailNotification(BaseNotification):  # pylint: disable=too-few-public-met
             f"""
             <html>
               <head>
-                <style type="text/css">
+                <meta http-equiv="content-type" content="text/html; charset=windows-1252" />
+                <meta charset="UTF-8" />
+                <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+                <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+                <style>
                   table, th, td {{
                     border-collapse: collapse;
                     border-color: rgb(200, 212, 227);
@@ -174,12 +178,78 @@ class EmailNotification(BaseNotification):  # pylint: disable=too-few-public-met
                   }}
                 </style>
               </head>
-              <body>
-                <div>{description}</div>
-                <br>
-                <b><a href="{self._content.url}">{call_to_action}</a></b><p></p>
-                {html_table}
-                {img_tag}
+              <body style="background-color: #ececec; padding: 30px 0; margin: 0">
+                <table
+                  style="background-color: #ffffff; padding: 0 0px"
+                  cellspacing="0"
+                  cellpadding="10"
+                  border="0"
+                  align="center"
+                >
+                  <tbody>
+                    <tr>
+                      <td style="padding: 0px 30px 50 30px">
+                        <table
+                          style="
+                            font-family: Inter, 'Helvetica Neue Light', 'Helvetica Regular',
+                              Arial, sans-serif;
+                            font-size: 16px;
+                            line-height: 26px;
+                          "
+                          cellspacing="0"
+                          cellpadding="10"
+                          border="0"
+                          align="center"
+                        >
+                          <tbody>
+                            <tr>
+                              <td style="padding: 40px 50px" align="center">
+                                <img
+                                  src="https://www.remita.net/assets/minimal/images/remita_orange_new_logo.svg"
+                                  width="100px;"
+                                />
+                              </td>
+                            </tr>
+                            <tr>
+                              <td
+                                style="
+                                  background: #fff;
+                                  border-top-left-radius: 16px;
+                                  border-top-right-radius: 16px;
+                                  line-height: 23px !important;
+                                "
+                              >
+                                <div>Hello ,</div>
+                                <br />
+                                <div>{description}</div>
+                                <br />
+                                <p></p>
+                                {html_table} {img_tag}
+                                <br />
+                                <b><a href="{self._content.url}">{call_to_action}</a></b>
+                              </td>
+                            </tr>
+                            <tr>
+                              <td
+                                style="
+                                  padding: 10px 20px;
+                                  background: #f7f9fc;
+                                  text-align: center;
+                                  font-size: 14px;
+                                "
+                              >
+                                <p style="margin-bottom: 30px">
+                                  You received this email because you signed up to Remita. Please do not reply this email as it is automatically generated and unmanned.
+                                </p>
+                                <p>&copy; {datetime.now().year} Remita Payment Services Limited</p>
+                              </td>
+                            </tr>
+                          </tbody>
+                        </table>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
               </body>
             </html>
             """


### PR DESCRIPTION
This PR introduces a Remita-branded HTML email template for reports.\n\n- Adds branding, header layout, and a footer disclaimer\n- Preserves NH3 sanitization and table-only embedded data rendering\n- Includes CTA link and optional screenshots\n\nThe styling is confined to the email notification renderer and does not affect chart logic.